### PR TITLE
Add workaround for handling Apple mobile phone devices in China

### DIFF
--- a/SSW.DetectService.js
+++ b/SSW.DetectService.js
@@ -1,9 +1,14 @@
 ﻿/* 
- * SSW Service Detector - Brendan Richards Dec 2018
- * =================================================
+ * SSW Service Detector - Brendan Richards Dec 2018 
+ * ============================================================================
  * 
- * This js detects our ability to use various 3rd party services - by attempting to load the favicon from that service's website.
+ * This js detects our ability to use various 3rd party services that may not be available behind the China firewall by attempting to load the favicon from that service's website.
  * For example, youtube is completely blocked from inside china so we can't use any youtube features.
+ *
+ * Include this library on pages where you want to test whether the services are available
+ *
+ * Browsers on Apple mobile devices, iphone/ipads, were not handling the setTimeout and clearTimeout, so as a workaround,
+ * if it is detected that the user is on an Apple mobile device and their ip geolocation is "cn", then the services is deemed as unavailable.
  * 
  * Detection takes time so we trigger document-level jquery events to run code after the detection has finished
  * $(document).trigger("DetectServiceComplete", service);
@@ -28,22 +33,21 @@ function ServiceForDetection(name, favicon) {
     this.favicon = favicon;
     this.testComplete = false;
     this.successful = false;
-};
-
+}
 
 function DoDetectService(service) {
     var image = new Image();
-    var timer = window.setTimeout(() => {
-        console.log('Detect fail for ' + service.name);
+    var timer = window.setTimeout(function () {
+        //console.log('Detect fail for ' + service.name);
         image.src = '';
         image.onload = null;
         image.onerror = null;
         service.testComplete = true;
         $(document).trigger("DetectServiceComplete", service);
     }, 1500);
-    image.onload = function() {
+    image.onload = function () {
         clearTimeout(timer);
-        console.log('Detect pass for ' + service.name);
+        //console.log('Detect pass for ' + service.name);
         service.successful = true;
         service.testComplete = true;
         $(document).trigger("DetectServiceComplete", service);
@@ -51,20 +55,52 @@ function DoDetectService(service) {
     image.src = service.favicon;
 }
 
-
-$(document).ready(function() {
-
-    window.serviceDetector = {
-        youtube:   new ServiceForDetection("youtube", "https://youtube.com/favicon.ico"),
-        google:    new ServiceForDetection("google", "https://google.com/favicon.ico"),
-        facebook: new ServiceForDetection("facebook", "https://facebook.com/favicon.ico"),
-        youku: new ServiceForDetection("youku", "https://static.youku.com/v1.0.166/index/img/favicon.ico")
-    };
-
-    for (var service in window.serviceDetector) {
+function DoDetectServiceBasedOnCountryCode(countryCode) {
+    //console.log('DetectBasedOnCountry: ', countryCode);
+    //console.log('User based in China: ', countryCode.toLowerCase() === 'cn');
+    for (var service in serviceDetector) {
         if (window.serviceDetector.hasOwnProperty(service)) {
-            DoDetectService(window.serviceDetector[service]);
+            window.serviceDetector[service].testComplete = true;
+            if (countryCode.toLowerCase() === 'cn') {
+                window.serviceDetector[service].successful = service.toLowerCase() === 'youku' ? true : false;                
+            } else {                
+                window.serviceDetector[service].successful = true;
+            }
+            $(document).trigger("DetectServiceComplete", service);
         }
     }
-});
+    //console.log('window.ServiceDetector object after: ', window.serviceDetector);
+}
 
+function isAppleMobileDevice() {
+    var match = /iphone|ipad|ipod/i.test(navigator.userAgent.toLowerCase());
+    //console.log('isAppleMobileDevice: ', match);
+    return match;
+}
+
+$(document).ready(function () {
+
+    window.serviceDetector = {
+        vimeo: new ServiceForDetection("vimeo", "https://vimeo.com/favicon.ico"),
+        youtube: new ServiceForDetection("youtube", "https://youtube.com/favicon.ico"),
+        youku: new ServiceForDetection("youku", "https://static.youku.com/v1.0.166/index/img/favicon.ico"),
+        google: new ServiceForDetection("google", "https://www.google.com/favicon.ico"),
+        facebook: new ServiceForDetection("facebook", "https://facebook.com/favicon.ico")
+    };
+
+    if (isAppleMobileDevice()) {
+        $.ajax({
+            type: 'GET',
+            url: 'https://ipapi.co/country',
+            success: function (data) {
+                DoDetectServiceBasedOnCountryCode(data);
+            }
+        });
+    } else {
+        for (var service in window.serviceDetector) {
+            if (window.serviceDetector.hasOwnProperty(service)) {
+                DoDetectService(window.serviceDetector[service]);
+            }
+        }
+    }    
+});


### PR DESCRIPTION
Hi Brendan, 
I've added this work around for handling the detection if done from an Apple mobile device.  It's to overcome an issue we found with testing in China where the SSW Website pages were taking over 1m30s to complete loading when viewed from an Apple mobile device. The issue didn't affect Android devices.

If an Apple device agent is detected, then I'm checking whether the IP Geolocation is CN.  If it is, then I mark all the services (except youku) as false.

Regards
Barry